### PR TITLE
I think this is all that's needed

### DIFF
--- a/audioop/_audioop.c
+++ b/audioop/_audioop.c
@@ -1981,6 +1981,7 @@ audioop_exec(PyObject* module)
 static PyModuleDef_Slot audioop_slots[] = {
     {Py_mod_exec, audioop_exec},
     {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
     {0, NULL}
 };
 


### PR DESCRIPTION
~~I need to double-check a few things later, but conceptually, this should be all that's needed since this already wasn't manually manipulating the GIL or relying on it implicitly.~~

Should be ready to go, wheel built fine and imported fine on beta 1 on linux, and there shouldn't be anything platform specific about this.