### PR TITLE
Account for `PyUnicode_AsUTF8AndSize` possibly returning `NULL`.

### DIFF
--- a/audioop/_audioop.c.h
+++ b/audioop/_audioop.c.h
@@ -66,6 +66,11 @@ _LTS_PyArg_BadArgument(const char *fname, const char *displayname,
     }
 
     const char *arg_type_name_chars = PyUnicode_AsUTF8AndSize(arg_type_name, NULL);
+    if (arg_type_name_chars == NULL) {
+        Py_DECREF(arg_type_name);
+        Py_DECREF(arg_type);
+        return;
+    }
 
     PyErr_Format(PyExc_TypeError,
                  "%.200s() %.200s must be %.50s, not %.50s",


### PR DESCRIPTION
I missed this in my previous PR.

Reference: https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_AsUTF8AndSize