### PR TITLE
Run tests after building wheels

### DIFF
--- a/.github/workflows/build-ci.yaml
+++ b/.github/workflows/build-ci.yaml
@@ -12,32 +12,9 @@ on:
     types: [opened, reopened, synchronize]
 
 jobs:
-  install_and_test:
-    name: Install project and test on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.13.0-beta.1"
-
-      - name: "Install project on ${{ matrix.os }}"
-        run: |
-          pip install .
-
-      - name: Run tests on ${{ matrix.os }}
-        run: |
-          python tests/test_audioop.py
-
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    needs: [install_and_test]
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
@@ -75,7 +52,7 @@ jobs:
     name: Publish built wheels to Pypi
     runs-on: ubuntu-latest
     environment: release
-    needs: [install_and_test, build_wheels]
+    needs: [make-sdist, build_wheels]
     permissions:
       id-token: write
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,7 @@ ignore = [
 ]
 reportPrivateUsage = "none"
 reportUnnecessaryTypeIgnoreComment = "warning"
+
+# configuration common between all platforms, rest is defined in the GH Actions workflow
+[tool.cibuildwheel]
+test-command = "python {project}/tests/test_audioop.py"


### PR DESCRIPTION
This PR makes cibuildwheel test the wheels themselves by installing them and running the tests in an isolated env after the build.

Additionally, I figured there is probably no point in duplicating the same work and I removed the `install_and_test` job that the wheel build depended on. While doing so, I noticed that the `needs` for `upload_pypi` job doesn't actually depend on the sdist job to finish, even though it requires its output so I fixed that at the same time.

I think that adding the `test-command` itself is probably non-controversial but I'm not as sure about `install_and_test`. Let me know, if you think that I should keep it.

----

Since I also made  #14 at the same time, I ran a workflow job with both of these merged here:
https://github.com/Jackenmen/audioop/actions/runs/10220145547?pr=3
The ideal scenario would be to have both of these merged to ensure that the cross-compiled wheels pass the tests. I should note that **the Windows ARM64 build can only be tested on an arm64 runner** and therefore that could not be tested.