### PR TITLE
Cross-compile wheels for Windows ARM64 and Linux aarch64/ppc64le/s390x

### DIFF
--- a/.github/workflows/build-ci.yaml
+++ b/.github/workflows/build-ci.yaml
@@ -45,11 +45,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19.2
         env:
           CIBW_BUILD: "cp313-*"
           CIBW_ARCHS_MACOS: all
+          CIBW_ARCHS_LINUX: auto aarch64 ppc64le s390x
+          CIBW_ARCHS_WINDOWS: auto ARM64
           CIBW_PRERELEASE_PYTHONS: true
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/build-ci.yaml
+++ b/.github/workflows/build-ci.yaml
@@ -40,7 +40,28 @@ jobs:
     needs: [install_and_test]
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        include:
+          # macOS Intel & ARM
+          - os: macos-latest
+            archs: all
+          # Windows x86 32-bit and 64-bit
+          - os: windows-latest
+            archs: auto
+          # Windows ARM
+          - os: windows-latest
+            archs: ARM64
+          # Linux x86 32-bit and 64-bit
+          - os: ubuntu-latest
+            archs: auto
+          # Linux aarch64
+          - os: ubuntu-latest
+            archs: aarch64
+          # Linux ppc64le
+          - os: ubuntu-latest
+            archs: ppc64le
+          # Linux s390x
+          - os: ubuntu-latest
+            archs: s390x
 
     steps:
       - uses: actions/checkout@v4
@@ -55,14 +76,12 @@ jobs:
         uses: pypa/cibuildwheel@v2.19.2
         env:
           CIBW_BUILD: "cp313-*"
-          CIBW_ARCHS_MACOS: all
-          CIBW_ARCHS_LINUX: auto aarch64 ppc64le s390x
-          CIBW_ARCHS_WINDOWS: auto ARM64
+          CIBW_ARCHS: ${{ matrix.archs }}
           CIBW_PRERELEASE_PYTHONS: true
 
       - uses: actions/upload-artifact@v4
         with:
-          name: artifact-cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          name: artifact-cibw-wheels-${{ matrix.os }}-${{ matrix.archs }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
 
   make-sdist:

--- a/.github/workflows/build-ci.yaml
+++ b/.github/workflows/build-ci.yaml
@@ -35,7 +35,7 @@ jobs:
           python tests/test_audioop.py
 
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheels on ${{ matrix.os }} [${{ matrix.archs }}]
     runs-on: ${{ matrix.os }}
     needs: [install_and_test]
     strategy:


### PR DESCRIPTION
This PR adds wheels for more platforms! Notably, Windows ARM64 and Linux aarch64 are now built. Since the package can be built on ppc64le and s390x platforms as well, I enabled that too.

To make sure that the total time of the build doesn't skyrocket, I split out the native and emulated builds in the job matrix ([c12729b](https://github.com/AbstractUmbra/audioop/commit/c12729bc4ba7d0abf3904bb37e344bdffc399781)). This makes it so that the build takes ~4 minutes rather ~13-14 minutes.

----

Since I also made #13 at the same time, I ran a workflow job with both of these merged here:
https://github.com/Jackenmen/audioop/actions/runs/10220145547?pr=3
The ideal scenario would be to have both of these merged to ensure that the cross-compiled wheels pass the tests. I should note that **the Windows ARM64 build can only be tested on an arm64 runner** and therefore that could not be tested.