### PR TITLE
Build wheels for free-threaded (no-GIL) Python

### DIFF
--- a/.github/workflows/build-ci.yaml
+++ b/.github/workflows/build-ci.yaml
@@ -52,9 +52,10 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19.2
         env:
-          CIBW_BUILD: "cp313-*"
+          CIBW_BUILD: "cp313-* cp3*t-*"
           CIBW_ARCHS: ${{ matrix.archs }}
           CIBW_PRERELEASE_PYTHONS: true
+          CIBW_FREE_THREADED_SUPPORT: true
 
       - uses: actions/upload-artifact@v4
         with:

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,23 @@
+import sysconfig
+
 from setuptools import Extension, setup
+
+
+Py_GIL_DISABLED = sysconfig.get_config_var("Py_GIL_DISABLED")
+macros = []
+options = {}
+if not Py_GIL_DISABLED:
+    macros.append(("Py_LIMITED_API", "0x030D0000"))
+    options["bdist_wheel"] = {"py_limited_api": "cp313"}
 
 extensions = [
     Extension(
         name="audioop._audioop",
         sources=["audioop/_audioop.c"],
         depends=["audioop/_audioop.c.h"],
-        define_macros=[("Py_LIMITED_API", "0x030D0000")],
-        py_limited_api=True,
+        define_macros=macros,
+        py_limited_api=not Py_GIL_DISABLED,
     )
 ]
-
-options = {"bdist_wheel": {"py_limited_api": "cp313"}}
 
 setup(ext_modules=extensions, options=options)


### PR DESCRIPTION
Enables free-threaded builds and updates the build configuration to not use Limited API on free-threaded Python since it does not support them yet. The lack of support for Limited API means that wheels for **free-threaded** Python will need to be built every time new Python 3.x.0-rc1 (along with CIBW supporting it) is released. Regular Python is not affected and that's why the build tag only uses the wildcard for free-threaded one.