### PR TITLE
Release version 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "audioop-lts"
 description = "LTS Port of Python audioop"
 requires-python = ">=3.13"
-version = "0.1.0"
+version = "0.2.0"
 readme = "README.md"
 license = { text = "PSF-2.0" }
 maintainers = [{ name = "AbstractUmbra", email = "umbra@abstractumbra.dev" }]


### PR DESCRIPTION
This version change adds more build architectures for our distributed wheels, as well as corrects the builds for free threading builds of Python (no GIL).

Thanks to @Jackenmen for the work on this!