### PR TITLE
Bump CIBW to version with 3.13.0rc1 (ABI compatibility with final release)

### DIFF
--- a/.github/workflows/build-ci.yaml
+++ b/.github/workflows/build-ci.yaml
@@ -50,11 +50,10 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.19.2
+        uses: pypa/cibuildwheel@v2.20.0
         env:
           CIBW_BUILD: "cp313-* cp3*t-*"
           CIBW_ARCHS: ${{ matrix.archs }}
-          CIBW_PRERELEASE_PYTHONS: true
           CIBW_FREE_THREADED_SUPPORT: true
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
I missed the date by a day, I would have PRed it before 0.2.0 if I knew :P
https://github.com/pypa/cibuildwheel/releases/tag/v2.20.0