### PR TITLE
Add build and release for `riscv64` arch.

### DIFF
--- a/.github/workflows/build-ci.yaml
+++ b/.github/workflows/build-ci.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feat/*
     tags:
       - "*.*.*"
     paths:
@@ -44,6 +45,8 @@ jobs:
           # Linux s390x
           - os: ubuntu-latest
             archs: s390x
+          - os: ubuntu-latest
+            archs: riscv64
 
     steps:
       - uses: actions/checkout@v4
@@ -55,7 +58,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.1.1
+        uses: pypa/cibuildwheel@v3.1.3
         env:
           CIBW_BUILD: "cp313-* cp313t-* cp314-* cp314t-*"
           CIBW_ARCHS: ${{ matrix.archs }}


### PR DESCRIPTION
Supercedes #40 

This PR will add another matrix to the build ci for the `riscv64` architecture.
This was successful in [the following run](https://github.com/AbstractUmbra/audioop/actions/runs/16753765132).